### PR TITLE
Update info-box link to fixed-info-box

### DIFF
--- a/files/en-us/learn/accessibility/css_and_javascript/index.md
+++ b/files/en-us/learn/accessibility/css_and_javascript/index.md
@@ -200,7 +200,7 @@ Another tip is to not rely on color alone for signposts/information, as this wil
 
 ### Hiding things
 
-There are many instances where a visual design will require that not all content is shown at once. For example, in our [Tabbed info box example](https://mdn.github.io/learning-area/css/css-layout/practical-positioning-examples/info-box.html) (see [source code](https://github.com/mdn/learning-area/blob/main/css/css-layout/practical-positioning-examples/info-box.html)) we have three panels of information, but we are [positioning](/en-US/docs/Learn/CSS/CSS_layout/Positioning) them on top of one another and providing tabs that can be clicked to show each one (it is also keyboard accessible — you can alternatively use Tab and Enter/Return to select them).
+There are many instances where a visual design will require that not all content is shown at once. For example, in our [Tabbed info box example](https://mdn.github.io/learning-area/css/css-layout/practical-positioning-examples/fixed-info-box.html) (see [source code](https://github.com/mdn/learning-area/blob/main/css/css-layout/practical-positioning-examples/fixed-info-box.html)) we have three panels of information, but we are [positioning](/en-US/docs/Learn/CSS/CSS_layout/Positioning) them on top of one another and providing tabs that can be clicked to show each one (it is also keyboard accessible — you can alternatively use Tab and Enter/Return to select them).
 
 ![Three tab interface with Tab 1 selected and only its contents are displayed. The contents of other tabs are hidden. If a tab is selected, then it's text-color changes from black to white and the background-color changes from orange-red to saddle brown.](tabbed-info-box.png)
 


### PR DESCRIPTION
### Description
Updated link to tabbed info box example and source code in [hiding things section](https://developer.mozilla.org/en-US/docs/Learn/Accessibility/CSS_and_JavaScript#hiding_things). from `info-box.html` to `fixed-info-box.html`, assuming that is the updated file with a different name.

Maybe changing the name of the file directly would be better, but wasn't sure if it was referenced anywhere else

### Motivation
The current links are 404